### PR TITLE
refacored api routes to use month/year as optional params

### DIFF
--- a/client/src/containers/TrainingModal/TrainingModal.js
+++ b/client/src/containers/TrainingModal/TrainingModal.js
@@ -67,7 +67,7 @@ class TrainingModal extends React.Component {
     }
     handleChange = (date) => {
         this.setState({
-            date: date.valueOf() // sets the unix time!
+            date: date 
         });
     }
     handleAdd = (event) => {

--- a/client/src/pages/Athlete/Athlete.js
+++ b/client/src/pages/Athlete/Athlete.js
@@ -55,16 +55,12 @@ class Athlete extends React.Component {
     addTraining = training => {
         // will hit API to add training and then update the calObject with new training
         let {calObject} = this.state;
-        let {startUnix, endUnix} = calObject;
-        API.getTrainingStats(startUnix, endUnix)
-        .then(stats => {
-            this.setState({trainingStats: stats});
-        })
-        .catch(err => console.log(err));
         API.addTraining(training).then(training => {
-            let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, calObject);
+            let updatedCalObject = training ? dateHelpers.insertTrainingIntoCalObject(training, calObject) : calObject;
             this.setState({
                 calObject: updatedCalObject
+            }, () => {
+                this.getStats(calObject);
             });
         })
         .catch(err => console.log(err));
@@ -72,14 +68,14 @@ class Athlete extends React.Component {
     deleteTraining = id => {
         // will hit API to delete training and then update the calObject with new training
         let {calObject} = this.state;
-        let {startUnix, endUnix} = calObject;
-        API.getTrainingStats(startUnix, endUnix)
+        let {year, monthNum} = calObject;
+        API.getTrainingStats(year, monthNum)
         .then(stats => {
             this.setState({trainingStats: stats});
         })
         .catch(err => console.log(err));
         API.deleteTraining(id).then(training => {
-            let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, calObject);
+            let updatedCalObject = training ? dateHelpers.insertTrainingIntoCalObject(training, calObject) : calObject;
             this.setState({
                 calObject: updatedCalObject
             });
@@ -89,14 +85,14 @@ class Athlete extends React.Component {
     updateTraining = (training, id) => {
         // will hit API to update training and then update the calObject with new training
         let {calObject} = this.state;
-        let {startUnix, endUnix} = calObject;
-        API.getTrainingStats(startUnix, endUnix)
+        let {year, monthNum} = calObject;
+        API.getTrainingStats(year, monthNum)
         .then(stats => {
             this.setState({trainingStats: stats});
         })
         .catch(err => console.log(err));
         API.editTraining(training, id).then(training => {
-            let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, calObject);
+            let updatedCalObject = training ? dateHelpers.insertTrainingIntoCalObject(training, calObject) : calObject;
             this.setState({
                 calObject: updatedCalObject
             });
@@ -107,15 +103,15 @@ class Athlete extends React.Component {
         // go forward one full timeframe unit, then populate the object with training from the DB
         let {calObject} = this.state;
         let forwardCalObject = dateHelpers.nextMonth(calObject);
-        let {startUnix, endUnix} = forwardCalObject;
-        API.getTrainingStats(startUnix, endUnix)
+        let {year, monthNum} = forwardCalObject;
+        API.getTrainingStats(year, monthNum)
         .then(stats => {
             this.setState({trainingStats: stats});
         })
         .catch(err => console.log(err));
-        API.getTraining(startUnix, endUnix)
+        API.getTraining(year, monthNum)
         .then(training => {
-            let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, forwardCalObject);
+            let updatedCalObject = training ? dateHelpers.insertTrainingIntoCalObject(training, forwardCalObject) : forwardCalObject;
             console.log(updatedCalObject);
             this.setState({
                 calObject: updatedCalObject
@@ -127,15 +123,15 @@ class Athlete extends React.Component {
         // go backward one full timeframe unit
         let {calObject} = this.state;
         let backwardCalObject = dateHelpers.prevMonth(calObject);
-        let {startUnix, endUnix} = backwardCalObject;
-        API.getTrainingStats(startUnix, endUnix)
+        let {year, monthNum} = backwardCalObject;
+        API.getTrainingStats(year, monthNum)
         .then(stats => {
             this.setState({trainingStats: stats});
         })
         .catch(err => console.log(err));
-        API.getTraining(startUnix, endUnix)
+        API.getTraining(year, monthNum)
         .then(training => {
-            let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, backwardCalObject);
+            let updatedCalObject = training ? dateHelpers.insertTrainingIntoCalObject(training, backwardCalObject) : backwardCalObject;
             console.log(updatedCalObject);
             this.setState({
                 calObject: updatedCalObject
@@ -145,15 +141,15 @@ class Athlete extends React.Component {
     }
     currentTimeframe = () => {
         let currentCalObject = dateHelpers.initialize();
-        let {startUnix, endUnix} = currentCalObject;
-        API.getTrainingStats(startUnix, endUnix)
+        let {monthNum, year} = currentCalObject;
+        API.getTrainingStats(year, monthNum)
         .then(stats => {
             this.setState({trainingStats: stats});
         })
         .catch(err => console.log(err));
-        API.getTraining(startUnix, endUnix)
+        API.getTraining(year, monthNum)
         .then(training => {
-            let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, currentCalObject);
+            let updatedCalObject = training ? dateHelpers.insertTrainingIntoCalObject(training, currentCalObject) : currentCalObject;
             this.setState({
                 calObject: updatedCalObject
             });
@@ -163,21 +159,31 @@ class Athlete extends React.Component {
     componentDidMount = () => {
         // get training within the current timeframe and add it to the days that it happened (in the calObject)
         let {calObject} = this.state;
-        let startTime = calObject.startUnix;
-        let endTime = calObject.endUnix;
-        API.getTrainingStats(startTime, endTime)
+        console.log(calObject);
+        let month = calObject.monthNum;
+        let year = calObject.year;
+        API.getTrainingStats(year, month)
         .then(stats => {
             this.setState({trainingStats: stats});
         })
         .catch(err => console.log(err));
-        API.getTraining(startTime, endTime)
+        API.getTraining(year, month)
         .then(training => {
+            console.log(training);
             let updatedCalObject = dateHelpers.insertTrainingIntoCalObject(training, calObject);
             this.setState({
                 calObject: updatedCalObject
             });
         })
         .catch(err => console.log(err)); 
+    }
+    getStats = (calObject) => {
+        let {year, monthNum} = calObject;
+        API.getTrainingStats(year, monthNum)
+        .then(stats => {
+            this.setState({trainingStats: stats});
+        })
+        .catch(err => console.log(err));
     }
     updateTrainingAndStats = (training, someCalObject) => {
         // function to run in pretty much all of the above setStates

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,11 +1,23 @@
 const API = {
-    getTraining: async (startTime, endTime) => {
-        let response = await fetch(`/api/training/${startTime}/${endTime}`);
+    getTraining: async (year, month) => {
+        let date;
+        if (month) {
+            date = `${year}/${month}`;
+        } else {
+            date = year;
+        }
+        let response = await fetch(`/api/training/${date}`);
         let training = await response.json();
-        return training;
+        return training.training ? training.training : null; // training is an array even when you only return training...
     },
-    getTrainingStats: async (startTime, endTime) => {
-        let response = await fetch(`/api/stats/${startTime}/${endTime}`);
+    getTrainingStats: async (year, month) => {
+        let date;
+        if (month) {
+            date = `${year}/${month}`;
+        } else {
+            date = year;
+        }
+        let response = await fetch(`/api/stats/${date}`);
         let stats = await response.json();
         console.log(stats);
         return stats;

--- a/client/src/utils/dateHelpers.js
+++ b/client/src/utils/dateHelpers.js
@@ -44,20 +44,18 @@ const dateHelpers = {
                 training: training
             }, data);
         });
-        // add some unix start and stop times in the calObject for API searching
-        let i = calObject.calendar.length - 1;
-        let j = calObject.calendar[i].length -1;
-        calObject.startUnix = moment(calObject.calendar[0][0].date).startOf('day').valueOf(); // gets value in ms
-        calObject.endUnix = moment(calObject.calendar[i][j].date).endOf('day').valueOf();
+        // add month number into calObject for API searching
+        calObject.monthNum = new Date(`${calObject.month} ${calObject.year}`).getMonth() + 1
         return calObject;
     },
-    insertTrainingIntoCalObject: function(training, calObject) {
+    insertTrainingIntoCalObject: function (training, calObject) {
         // will add training to each day object where there is training
         let reformattedTraining = training.map(activity => {
             return Object.assign({
                 reformattedDate: moment(activity.date).format("MM/DD/YYYY")
             }, activity);
         });
+        console.log(reformattedTraining);
         // loop through the calendar nested array and add the training array for each day that matches the formatted date
         let updatedCalendar = calObject.calendar.map(week => {
             for (let i = 0; i < week.length; i++) {

--- a/models/User.js
+++ b/models/User.js
@@ -4,9 +4,9 @@ const Schema = mongoose.Schema;
 
 const trainingSchema = new Schema({
     date: {
-        type: Number,
+        type: Date,
         required: true,
-        default: Date.now() //milliseconds since Jan 1 1970
+        default: new Date() // date object
     },
     duration: {
         type: Number,


### PR DESCRIPTION
refactored api routes to use optional year and month params instead of a complicated unix date object. this makes the coach routes easier potentially.